### PR TITLE
DKCKZ-464 Изменен процесс удаления Аналогов и Аксессуаров

### DIFF
--- a/backend/src/Features/Accessory/Service/AccessoryActionService.php
+++ b/backend/src/Features/Accessory/Service/AccessoryActionService.php
@@ -152,7 +152,7 @@ final readonly class AccessoryActionService implements ActionInterface
     public function delete(MessageDTOInterface $dto): ?AbstractErrorMessage
     {
         /** @var AccessoryMessageDTO $dto */
-        $this->accessoryRepository->markAsDeleted($dto->id);
+        $this->accessoryRepository->delete($dto->id);
 
         $this->logger->info("Accessory with id '$dto->id' marked as deleted");
 

--- a/backend/src/Features/Analog/Service/AnalogActionService.php
+++ b/backend/src/Features/Analog/Service/AnalogActionService.php
@@ -149,7 +149,7 @@ final readonly class AnalogActionService implements ActionInterface
     public function delete(MessageDTOInterface $dto): ?AbstractErrorMessage
     {
         /** @var AnalogMessageDTO $dto */
-        $this->analogRepository->markAsDeleted($dto->id);
+        $this->analogRepository->delete($dto->id);
 
         $this->logger->info("Analog with id '$dto->id' marked as deleted");
 

--- a/backend/src/Helper/Abstract/AbstractAnalogAccessoryRepository.php
+++ b/backend/src/Helper/Abstract/AbstractAnalogAccessoryRepository.php
@@ -23,6 +23,15 @@ abstract class AbstractAnalogAccessoryRepository extends ServiceDocumentReposito
             ->execute();
     }
 
+    public function delete(string $id): void
+    {
+        $this->createQueryBuilder()
+            ->remove()
+                ->field('externalId')->equals($id)
+            ->getQuery()
+            ->execute();
+    }
+
     public function markAsDeleted(string $id): void
     {
         $this->createQueryBuilder()


### PR DESCRIPTION
# Технологические изменения

При обновлении данных в Битрикс фактически происходит их пересоздание, в сервис прилетает сначала удаление а потом повторное создание элемента. Это значит, что процесс отложенного удаления не дает создать обновленный элемент из-за дублирования связки товар - аналог/аксессуар.

В этом PR отложенное удаление заменено на непосредственное при обработке данных.

https://track.ratio.digital/youtrack/issue/DKCKZ-464