### PR TITLE
DKCKZ-471 Доработана команда обрабатывающая данные из временного хранилища

### DIFF
--- a/backend/src/Command/ProcessingDataFromTempStorageCommand.php
+++ b/backend/src/Command/ProcessingDataFromTempStorageCommand.php
@@ -152,7 +152,12 @@ final class ProcessingDataFromTempStorageCommand extends Command
                 $this->logger->error($e->getMessage());
                 $io->error("Error flush exception: " . $e->getMessage());
             } catch (BulkWriteException $e) {
-                $entityLogger->error($e->getMessage());
+                $entityLogger->error(
+                    sprintf(
+                        'Error flushed: %s',
+                        $e->getMessage()
+                    )
+                );
 
                 return Command::FAILURE;
             }

--- a/backend/src/Command/ProcessingDataFromTempStorageCommand.php
+++ b/backend/src/Command/ProcessingDataFromTempStorageCommand.php
@@ -153,6 +153,8 @@ final class ProcessingDataFromTempStorageCommand extends Command
                 $io->error("Error flush exception: " . $e->getMessage());
             } catch (BulkWriteException $e) {
                 $entityLogger->error($e->getMessage());
+
+                return Command::FAILURE;
             }
 
             $io->writeln(" <info>memory usage: " . $this->getCurrentMemoryUsage() . "</info>");
@@ -181,8 +183,6 @@ final class ProcessingDataFromTempStorageCommand extends Command
             } catch (MongoDBException $e) {
                 $this->logger->error($e->getMessage());
                 $io->error("Error flush exception: " . $e->getMessage());
-            } catch (BulkWriteException $e) {
-                $entityLogger->error($e->getMessage());
             }
 
             $io->writeln(" <info>memory usage: " . $this->getCurrentMemoryUsage() . "</info>");


### PR DESCRIPTION
# Технологические изменения
Если при сохранении данных (выполнение `flush`) происходит исключение, мы останавливаем работу скрипта.

https://track.ratio.digital/youtrack/issue/DKCKZ-471